### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-katago-cgos.yml
+++ b/.github/workflows/run-katago-cgos.yml
@@ -1,4 +1,6 @@
 name: Run KataGo on CGOS
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/changcheng967/Kata_web/security/code-scanning/1](https://github.com/changcheng967/Kata_web/security/code-scanning/1)

To fix the problem, we need to modify the workflow file `.github/workflows/run-katago-cgos.yml` to include an explicit `permissions` block, thereby setting the minimum necessary permissions for the GITHUB_TOKEN in this job. The best place for this block is at the top, immediately after the workflow name, applying to the whole workflow unless overridden elsewhere. In this case, given the job's actions (checkout code, setup environment, install dependencies, and run a script), the minimal permission required is `contents: read`. Thus, we should add the following YAML:

```yaml
permissions:
  contents: read
```

This block should be inserted after the `name:` field, before the `on:` trigger. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
