### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   setup-katago:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/changcheng967/Kata_web/security/code-scanning/2](https://github.com/changcheng967/Kata_web/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block at the job level (recommended for single-job workflows like this), specifying the minimal required permission. Since the workflow only checks out code and installs dependencies—actions that only require read access to the contents—set `permissions: contents: read` for the job. Edit the `.github/workflows/main.yml` file; insert the following block directly under the job name (`setup-katago:`), before `runs-on:`. No additional imports, definitions, or package changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
